### PR TITLE
Introduce runtime-config-loader to manually toggle webpack builds

### DIFF
--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -14,6 +14,7 @@ import {
   TemplateImportSyntax,
 } from './analyzer-syntax';
 import { Memoize } from 'typescript-memoize';
+import RuntimeConfigLoader from './runtime-config-loader';
 
 makeDebug.formatters.m = (modules: Import[]) => {
   return JSON.stringify(
@@ -93,6 +94,13 @@ export default class Analyzer extends Funnel {
 
   async build(...args: unknown[]) {
     await super.build(...args);
+
+    if (this.modules && this.modules.length) {
+      if (new RuntimeConfigLoader().skipAnalyzerOnRebuild) {
+        return;
+      }
+    }
+
     for (let [operation, relativePath] of this.getPatchset()) {
       switch (operation) {
         case 'unlink':

--- a/packages/ember-auto-import/ts/runtime-config-loader.ts
+++ b/packages/ember-auto-import/ts/runtime-config-loader.ts
@@ -1,0 +1,31 @@
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+
+export default class RuntimeConfigLoader {
+  get skipWebpackOnRebuild() {
+    return this.configOptions.skipWebpackOnRebuild;
+  }
+
+  get skipAnalyzerOnRebuild() {
+    return this.configOptions.skipAnalyzerOnRebuild;
+  }
+
+  private get configFilename() {
+    return join(process.cwd(), 'config', 'ember-auto-import.json');
+  }
+
+  private get configOptions(): Record<string, boolean> {
+    let options: Record<string, boolean> = {};
+    if (existsSync(this.configFilename)) {
+      let fileContents = readFileSync(this.configFilename, {
+        encoding: 'utf8',
+      });
+      try {
+        options = JSON.parse(fileContents);
+      } catch (err) {
+        console.warn(err);
+      }
+    }
+    return options;
+  }
+}

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -8,7 +8,7 @@ import type {
 } from 'webpack';
 import { join, dirname } from 'path';
 import { mergeWith, flatten, zip } from 'lodash';
-import { existsSync, writeFileSync, realpathSync } from 'fs';
+import { writeFileSync, realpathSync } from 'fs';
 import { compile, registerHelper } from 'handlebars';
 import jsStringEscape from 'js-string-escape';
 import { BundleDependencies, ResolvedTemplateImport } from './splitter';
@@ -20,7 +20,7 @@ import { Options } from './package';
 import { PackageCache } from '@embroider/shared-internals';
 import { Memoize } from 'typescript-memoize';
 import makeDebug from 'debug';
-import { ensureDirSync, symlinkSync } from 'fs-extra';
+import { ensureDirSync, symlinkSync, existsSync } from 'fs-extra';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import RuntimeConfigLoader from './runtime-config-loader';
 


### PR DESCRIPTION
which reads from the ember app's `config/ember-auto-import.json` when it is available

To use:
 1. clone this repo and `cd ember-auto-import`
 1. run `git fetch`
 1. run `git switch runtime-config-loader`
 1. run `npm install` in the top-level `ember-auto-import/` folder
 1. run `npm run compile` in `ember-auto-import/packages/ember-auto-import/`
 1. run `yarn link` in `ember-auto-import/packages/ember-auto-import/`
 1. `cd ~/Development/dashboard/frontend/dashboard/`
 1. `yarn link "ember-auto-import"`
 1. `cd ~/Development/dashboard/frontend/dashboard/config/`
 1. create `ember-auto-import.json` and add the following as its content:
```
{
  "skipAnalyzerOnRebuild": true,
  "skipWebpackOnRebuild": true
}
```
11. Start (or restart) your dashboard dev server

Once the server has started, make changes to your code. You should see faster rebuilds. You can toggle the flags to `false` to compare before/after speed of your rebuild. On an M1, I expect the improvement to be around 3 to 5 seconds. Impact varies a bit based on what kind of file you change (template, javascript, test, addon / app / engine)

For most development you can leave the flags set to `true`.

If you make a change to your code that adds an `import` _for a dependency from node_modules_, you may need to change the `ember-auto-import.json` booleans to `false` for it to pick that dependency up. Once you verify the dependency is available to your code, you can change the values back to `true` to get faster rebuilds again. This does not require restarting the development server.